### PR TITLE
Fixed no-namespace bug in Alert model

### DIFF
--- a/models.py
+++ b/models.py
@@ -417,6 +417,6 @@ def _set_firing_details(target, value, oldvalue, initiator):
     namespace_re = re.search(r"namespace = (.*)\n", value)
     try:
         target.namespace = namespace_re.group(1)
-    except IndexError as exc:
+    except (AttributeError, IndexError) as exc:
         logger.warning("%s's firing details are missing a namespace", target)
         logger.debug("Exception details", exc_info=exc)

--- a/test/sample_incident_alerts.json
+++ b/test/sample_incident_alerts.json
@@ -76,5 +76,83 @@
             "html_url": "https://redhat.pagerduty.com/services/PSXYZP1/integrations/PXXX0BT"
         },
         "privilege": null
+    },
+    {
+        "id": "Q7XYZ0P6XYZEC2",
+        "type": "alert",
+        "summary": "DNSErrors05MinSRE CRITICAL (13)",
+        "self": "https://api.pagerduty.com/alerts/Q2XYZ0W6XYZEC1",
+        "html_url": "https://redhat.pagerduty.com/alerts/Q2XYZ0W6XYZEC1",
+        "created_at": "2022-02-15T17:54:25Z",
+        "status": "resolved",
+        "resolved_at": "2022-02-15T18:34:25Z",
+        "alert_key": "e4c364c446a09a855044756a8abbeb1b530f103592533c77a0b29a01407a9",
+        "suppressed": false,
+        "service": {
+            "id": "PSXYZP1",
+            "type": "service_reference",
+            "summary": "osd-dummy.du4y.s1.openshiftapps.com-hive-cluster",
+            "self": "https://api.pagerduty.com/services/PSXYZP1",
+            "html_url": "https://redhat.pagerduty.com/service-directory/PSXYZP1"
+        },
+        "severity": "critical",
+        "incident": {
+            "id": "Q3DUM0MY38Q39W",
+            "type": "incident_reference",
+            "summary": "[#868037] [See SNow ticket in Notes] DNSErrors05MinSRE CRITICAL (6)",
+            "self": "https://api.pagerduty.com/incidents/Q3DUM0MY38Q39W",
+            "html_url": "https://redhat.pagerduty.com/incidents/Q3DUM0MY38Q39W"
+        },
+        "first_trigger_log_entry": {
+            "id": "R47CXYZYKT2WL00CS06Y6DI0RVT",
+            "type": "trigger_log_entry_reference",
+            "summary": "Triggered through the API",
+            "self": "https://api.pagerduty.com/log_entries/R47CXYZYKT2WL00CS06Y6DI0RVT",
+            "html_url": "https://redhat.pagerduty.com/alerts/Q2XYZ0W6XYZEC1/log_entries/R47CXYZYKT2WL00CS06Y6DI0RVT"
+        },
+        "body": {
+            "contexts": [],
+            "details": {
+                "alert_name": "DNSErrors05MinSRE",
+                "cluster_id": "e6a41234-1111-42e6-a780-123b1b10b64b",
+                "firing": "Labels:\n - alertname = DNSErrors05MinSRE\n - container = main\n",
+                "link": "https://github.com/openshift/ops-sop/tree/master/v4/alerts/DNSErrors05MinSRE.md",
+                "num_firing": "6",
+                "num_resolved": "0",
+                "ocm_link": "https://console.redhat.com/openshift/details/e6a41234-1111-42e6-a780-123b1b10b64b",
+                "resolved": ""
+            },
+            "cef_details": {
+                "client": "AlertManager",
+                "client_url": "https://dummy-monitoring.apps.dummy.du4y.s1.openshiftapps.com/#/alerts?receiver=pagerduty",
+                "contexts": [],
+                "dedup_key": "e4c364c446a09a883855044756a8abbeb1b111f103592533c77a0b29a01407a9",
+                "description": "DNSErrors05MinSRE CRITICAL (6)",
+                "details": {
+                    "alert_name": "DNSErrors05MinSRE",
+                    "cluster_id": "e6a41234-1111-42e6-a780-123b1b10b64b",
+                    "firing": "Labels:\n - alertname = DNSErrors05MinSRE\n - container = main\n",
+                    "link": "https://github.com/openshift/ops-sop/tree/master/v4/alerts/DNSErrors05MinSRE.md",
+                    "num_firing": "6",
+                    "num_resolved": "0",
+                    "ocm_link": "https://console.redhat.com/openshift/details/e6a41234-1111-42e6-a780-123b1b10b64b",
+                    "resolved": ""
+                },
+                "message": "DNSErrors05MinSRE CRITICAL (6)",
+                "mutations": [],
+                "severity": "critical",
+                "source_origin": "AlertManager",
+                "version": "1.0"
+            },
+            "type": "alert_body"
+        },
+        "integration": {
+            "id": "PXXX0BT",
+            "type": "events_api_v2_inbound_integration_reference",
+            "summary": "V4 Alertmanager",
+            "self": "https://api.pagerduty.com/services/PSXYZP1/integrations/PXXX0BT",
+            "html_url": "https://redhat.pagerduty.com/services/PSXYZP1/integrations/PXXX0BT"
+        },
+        "privilege": null
     }
 ]

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -300,54 +300,58 @@ class TestAlert(SQLAlchemyTestMixin, unittest.TestCase):
         self.session.add(inc)
         self.session.commit()
 
-        self.sample_alert = self.sample_incident_alerts[0]
-        alert = Alert.from_pd_api_response(
-            session=self.session, res_dict=self.sample_alert
-        )
-        self.session.add(alert)
-        self.session.commit()
+        self.sample_alerts = self.sample_incident_alerts
+        self.alert_ids = []
+        for alert_dict in self.sample_alerts:
+            alert = Alert.from_pd_api_response(
+                session=self.session, res_dict=alert_dict
+            )
+            self.session.add(alert)
+            self.session.commit()
 
-        self.alert_id = alert.id
+            self.alert_ids.append(alert.id)
 
     def test_from_pd_api_response(self):
         """
         Tests classmethod from_pd_api_response (called in setUp())
         """
-        alert = self.session.get(Alert, self.alert_id)
-        # Test basic field extraction
-        self.assertEqual(alert.pd_id, self.sample_alert["id"])
-        self.assertEqual(alert.html_url, self.sample_alert["html_url"])
-        self.assertEqual(alert.severity, self.sample_alert["severity"])
-        self.assertEqual(alert.suppressed, self.sample_alert["suppressed"])
-        self.assertEqual(alert.status, self.sample_alert["status"])
-        self.assertEqual(alert.name, self.sample_alert["body"]["details"]["alert_name"])
-        self.assertEqual(
-            alert.cluster_id, self.sample_alert["body"]["details"]["cluster_id"]
-        )
-        self.assertIn(alert.namespace, self.sample_alert["body"]["details"]["firing"])
+        alerts = self.session.query(Alert).filter(Alert.id.in_(self.alert_ids)).all()
+        for alert, sample_alert_dict in zip(alerts, self.sample_alerts):
+            # Test basic field extraction
+            self.assertEqual(alert.pd_id, sample_alert_dict["id"])
+            self.assertEqual(alert.html_url, sample_alert_dict["html_url"])
+            self.assertEqual(alert.severity, sample_alert_dict["severity"])
+            self.assertEqual(alert.suppressed, sample_alert_dict["suppressed"])
+            self.assertEqual(alert.status, sample_alert_dict["status"])
+            self.assertEqual(
+                alert.name, sample_alert_dict["body"]["details"]["alert_name"]
+            )
+            self.assertEqual(
+                alert.cluster_id, sample_alert_dict["body"]["details"]["cluster_id"]
+            )
+            self.assertIn(
+                alert.namespace, sample_alert_dict["body"]["details"]["firing"]
+            )
 
-        # Test incident relationship
-        self.assertEqual(alert.incident.pd_id, self.sample_alert["incident"]["id"])
+            # Test incident relationship
+            self.assertEqual(alert.incident.pd_id, sample_alert_dict["incident"]["id"])
 
-        # Test timestamps (cached_at, created_at, shift)
-        self.assertGreaterEqual(alert.cached_at, datetime.now() - timedelta(minutes=3))
-        sample_created_at = datetime.fromisoformat(
-            self.sample_alert["created_at"].replace("Z", "")
-        )
-        self.assertEqual(alert.created_at, sample_created_at)
-        sample_shift = Alert.calculate_shift(sample_created_at)
-        self.assertEqual(alert.shift, sample_shift)
-        ## resolved_at disabled as it seems to be an undocumented API field
-        # sample_resolved_at = datetime.fromisoformat(
-        #     self.sample_alert["resolved_at"].replace("Z", "")
-        # )
-        # self.assertEqual(alert.resolved_at, sample_resolved_at)
+            # Test timestamps (cached_at, created_at, shift)
+            self.assertGreaterEqual(
+                alert.cached_at, datetime.now() - timedelta(minutes=3)
+            )
+            sample_created_at = datetime.fromisoformat(
+                sample_alert_dict["created_at"].replace("Z", "")
+            )
+            self.assertEqual(alert.created_at, sample_created_at)
+            sample_shift = Alert.calculate_shift(sample_created_at)
+            self.assertEqual(alert.shift, sample_shift)
 
     def test_updated_alert(self):
         """
         Tests change of object attributes over time (e.g., due to alert resolution)
         """
-        updated_sample_alert = deepcopy(self.sample_alert)
+        updated_sample_alert = deepcopy(self.sample_alerts[0])
         updated_sample_alert["status"] = "triggered"
         updated_alert = Alert.from_pd_api_response(
             session=self.session, res_dict=updated_sample_alert
@@ -357,7 +361,7 @@ class TestAlert(SQLAlchemyTestMixin, unittest.TestCase):
         self.session.flush()
 
         # Now re-get from database
-        alert_under_test = self.session.get(Alert, self.alert_id)
+        alert_under_test = self.session.get(Alert, self.alert_ids)
         self.assertEqual(alert_under_test.pd_id, updated_sample_alert["id"])
         self.assertEqual(alert_under_test.status, "triggered")
 

--- a/test/test_models.py
+++ b/test/test_models.py
@@ -329,9 +329,11 @@ class TestAlert(SQLAlchemyTestMixin, unittest.TestCase):
             self.assertEqual(
                 alert.cluster_id, sample_alert_dict["body"]["details"]["cluster_id"]
             )
-            self.assertIn(
-                alert.namespace, sample_alert_dict["body"]["details"]["firing"]
-            )
+            # Only test for namespace if there is one in the firing details
+            if "namespace" in sample_alert_dict["body"]["details"]["firing"]:
+                self.assertIn(
+                    alert.namespace, sample_alert_dict["body"]["details"]["firing"]
+                )
 
             # Test incident relationship
             self.assertEqual(alert.incident.pd_id, sample_alert_dict["incident"]["id"])
@@ -361,7 +363,7 @@ class TestAlert(SQLAlchemyTestMixin, unittest.TestCase):
         self.session.flush()
 
         # Now re-get from database
-        alert_under_test = self.session.get(Alert, self.alert_ids)
+        alert_under_test = self.session.get(Alert, self.alert_ids[0])
         self.assertEqual(alert_under_test.pd_id, updated_sample_alert["id"])
         self.assertEqual(alert_under_test.status, "triggered")
 


### PR DESCRIPTION
There's a bug in the database event hook `Alert._set_firing_details()` that causes Alert database record creation to fail if a PagerDuty alert's firing_details field does not contain namespace info. The specific error is as follows:
```
ERROR:__main__:Failed to process alert Q0XYZTXYZIA6P
Traceback (most recent call last):
  File "/opt/app-root/src/updater.py", line 128, in update_alerts
    alert = Alert.from_pd_api_response(
  File "/opt/app-root/src/models.py", line 396, in from_pd_api_response
    alert.firing_details = res_dict["body"]["details"]["firing"]
  File "/opt/app-root/lib64/python3.9/site-packages/sqlalchemy/orm/attributes.py", line 459, in __set__
    self.impl.set(
  File "/opt/app-root/lib64/python3.9/site-packages/sqlalchemy/orm/attributes.py", line 1097, in set
    value = self.fire_replace_event(
  File "/opt/app-root/lib64/python3.9/site-packages/sqlalchemy/orm/attributes.py", line 1105, in fire_replace_event
    value = fn(
  File "/opt/app-root/lib64/python3.9/site-packages/sqlalchemy/orm/events.py", line 2266, in wrap
    fn(target, *arg)
  File "/opt/app-root/src/models.py", line 419, in _set_firing_details
    target.namespace = namespace_re.group(1)
AttributeError: 'NoneType' object has no attribute 'group'
```
This is due to an `AttributeError` raised when the code tries to fetch a non-existent regex result. With this PR, that exception will now be caught and logged as a warning. This PR also adds a sample alert that triggers this error to `sample_incident_alerts.json` and updates the unit tests for the Alert model such that they can now handle these multi-alert sample files.

This PR addresses bug OSD-10952.