### PR TITLE
Fixed QFlappingShift date boundary and summing bugs

### DIFF
--- a/questions.py
+++ b/questions.py
@@ -275,8 +275,9 @@ class QFlappingShift(Question):
         self._column_names = ["cluster", "name", "namespace", "urgency", "flaps"]
 
     def _query(self):
+        # First create a subquery that counts flaps per-shift-date
         flap_count = func.count("*").label("flap_count")
-        return (
+        subq = (
             self._db_session.query(Alert)
             .filter(Alert.created_at.between(self._since, self._until))
             .join(Incident)
@@ -295,7 +296,14 @@ class QFlappingShift(Question):
                 flap_count,
             )
             .having(flap_count > 1)
-            .order_by(desc(flap_count))
+        ).subquery()
+
+        # Then add up the flaps for alerts that flapped on multiple shift-days
+        flap_sum = func.sum(subq.c.flap_count).label("flap_sum")
+        return (
+            self._db_session.query(subq, flap_sum)
+            .group_by(subq.c.cluster_id, subq.c.name, subq.c.namespace, subq.c.urgency)
+            .order_by(desc(flap_sum))
         )
 
     def get_answer(self):

--- a/questions.py
+++ b/questions.py
@@ -278,6 +278,7 @@ class QFlappingShift(Question):
         flap_count = func.count("*").label("flap_count")
         return (
             self._db_session.query(Alert)
+            .filter(Alert.created_at.between(self._since, self._until))
             .join(Incident)
             .group_by(
                 Alert.cluster_id,


### PR DESCRIPTION
There's a bug in the definition of `_query()` for the Question subclass `QFlappingShift` (a.k.a. "Which alerts fire more than once per on-call shift (in the same cluster)?") where date boundaries (`since` and `until`) were not being considered, leading to increasingly-large results for that query. This PR fixes that bug by adding an SQLAlchemy  filter clause along the lines of:
```sql
WHERE alert.creation_time > time_window_start && alert.creation_time < time_window_end
``` 

There's also an undocumented bug in the above-mentioned method that caused flap counts to not be summed across days, leading to duplicate entries in the answer table. This PR fixes this by converting the original query into a subquery, and then returning a new query that sums across the subquery.

This PR addresses bug [OSD-11288](https://issues.redhat.com/browse/OSD-11288) (date boundaries).