### PR TITLE
Added QMostFrequent: Which alerts fire most frequently? 

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ AA_RW_DB_STRING=sqlite+pysqlite:///:memory: # Access a read-write account
 
 # QUESTION_CLASSES is a list of the questions you'd like to display on the web UI.
 # These should be class names from questions.py
-AA_QUESTION_CLASSES=QNeverAcknowledged:QNeverAcknowledgedSelfResolved:QFlappingShift
+AA_QUESTION_CLASSES=QMostFrequent:QNeverAcknowledgedSelfResolved:QFlappingShift
 ```
 *Note*: if you're just experimenting/testing, feel free the leave the SQLite database
 string shown above as is. Just know that this will create the database in-memory and

--- a/questions.py
+++ b/questions.py
@@ -138,6 +138,23 @@ class Question:
         return self._id
 
 
+class QMostFrequent(Question):
+    """
+    Which alerts fire most frequently?
+    """
+
+    def __init__(self, db_session, since, until):
+        super().__init__(db_session, since, until)
+        self._id = "mfreq"
+        self._description = "Which alerts fire most frequently?"
+
+    def _query(self):
+        # This super-simple question doesn't require any filters beyond the date range
+        return self._db_session.query(Alert).filter(
+            Alert.created_at.between(self._since, self._until)
+        )
+
+
 class QNeverAcknowledged(Question):
     """
     Which alerts have yet to be acknowledged by SRE?


### PR DESCRIPTION
This PR adds a simple but quite-useful `Question` to questions.py: `QMostFrequent`, a.k.a. which alerts fire most frequently? We also update the README's sample .env file to include this Question.

This addresses [OSD-11721](https://issues.redhat.com/browse/OSD-11721), where team leads requested this simple question in order to both make OAA more useful for ops reviews and allow advanced users to more-flexibly use OAA's frontend table filters.