### PR TITLE
Added region filtering and better webUI defaults

### DIFF
--- a/questions.py
+++ b/questions.py
@@ -153,16 +153,13 @@ class QMostFrequent(Question):
     Which alerts fire most frequently?
     """
 
-    def __init__(self, db_session, since, until):
-        super().__init__(db_session, since, until)
+    def __init__(self, db_session, since, until, region):
+        super().__init__(db_session, since, until, region)
         self._id = "mfreq"
         self._description = "Which alerts fire most frequently?"
 
-    def _query(self):
-        # This super-simple question doesn't require any filters beyond the date range
-        return self._db_session.query(Alert).filter(
-            Alert.created_at.between(self._since, self._until)
-        )
+    # This super-simple question doesn't require any filters beyond the date range, so
+    # we can use the parent class's implementation of _query()
 
 
 class QNeverAcknowledged(Question):
@@ -303,8 +300,8 @@ class QFlappingShift(Question):
         # First create a subquery that counts flaps per-shift-date
         flap_count = func.count("*").label("flap_count")
         subq = (
-            self._db_session.query(Alert)
-            .filter(Alert.created_at.between(self._since, self._until))
+            super()
+            ._query()
             .join(Incident)
             .group_by(
                 Alert.cluster_id,

--- a/questions.py
+++ b/questions.py
@@ -52,7 +52,7 @@ class Question:
     Base class for questions
     """
 
-    def __init__(self, db_session, since, until):
+    def __init__(self, db_session, since, until, region):
         """
         Constructor for Questions. Mainly sets up DB connection
 
@@ -61,9 +61,12 @@ class Question:
             which the question query will be evaluated
         :param until: a datetime.datetime containing the end of the time window over
             which the question query will be evaluated
+        :param region: a string representing the region (i.e., shift during which the
+            alert first fired) of the incidents queried (e.g., "NASA")
         """
         self._since = since
         self._until = until
+        self._region = region
         self._db_session = db_session
 
         self._column_names = STANDARD_COLUMNS.copy()
@@ -101,7 +104,14 @@ class Question:
         """
         Returns the SQLAlchemy query used to answer this Question
         """
-        raise NotImplementedError
+        # Filter solely on date range by default
+        base_query = self._db_session.query(Alert).filter(
+            Alert.created_at.between(self._since, self._until)
+        )
+        if not self._region or self._region == "Global":
+            return base_query
+        # Filter also on Region if specified
+        return base_query.filter(Alert.shift.contains(self._region))
 
     def get_answer(self):
         """
@@ -143,17 +153,15 @@ class QNeverAcknowledged(Question):
     Which alerts have yet to be acknowledged by SRE?
     """
 
-    def __init__(self, db_session, since, until):
-        super().__init__(db_session, since, until)
+    def __init__(self, db_session, since, until, region):
+        super().__init__(db_session, since, until, region)
         self._id = "nack"
         self._description = "Which alerts have yet to be acknowledged by SRE?"
 
     def _query(self):
         # The ~ operator negates the condition
         return (
-            self._db_session.query(Alert)
-            .filter(Alert.created_at.between(self._since, self._until))
-            .filter(Alert.incident.has(~Incident.acknowledged_by.any()))
+            super()._query().filter(Alert.incident.has(~Incident.acknowledged_by.any()))
         )
 
 
@@ -162,16 +170,16 @@ class QNeverAcknowledgedSelfResolved(Question):
     Which alerts self-resolve without acknowledgement?
     """
 
-    def __init__(self, db_session, since, until):
-        super().__init__(db_session, since, until)
+    def __init__(self, db_session, since, until, region):
+        super().__init__(db_session, since, until, region)
         self._id = "nacksres"
         self._description = "Which alerts self-resolve without acknowledgement?"
 
     def _query(self):
         # The ~ operator negates the condition
         return (
-            self._db_session.query(Alert)
-            .filter(Alert.created_at.between(self._since, self._until))
+            super()
+            ._query()
             .filter(Alert.incident.has(~Incident.acknowledged_by.any()))
             .filter(
                 Alert.incident.has(
@@ -186,16 +194,16 @@ class QAcknowledgedUnresolved(Question):
     Which alerts are acknowledged but never resolved?
     """
 
-    def __init__(self, db_session, since, until):
-        super().__init__(db_session, since, until)
+    def __init__(self, db_session, since, until, region):
+        super().__init__(db_session, since, until, region)
         self._id = "ackures"
         self._description = "Which alerts are acknowledged but never resolved?"
 
     def _query(self):
         # pylint: disable=singleton-comparison
         return (
-            self._db_session.query(Alert)
-            .filter(Alert.created_at.between(self._since, self._until))
+            super()
+            ._query()
             .filter(Alert.incident.has(Incident.acknowledged_by.any()))
             .filter(Alert.incident.has(Incident.resolved_at == None))
         )
@@ -206,16 +214,16 @@ class QSelfResolvedImmediately(Question):
     Which alerts self-resolve w/in 15 minutes?
     """
 
-    def __init__(self, db_session, since, until):
-        super().__init__(db_session, since, until)
+    def __init__(self, db_session, since, until, region):
+        super().__init__(db_session, since, until, region)
         self._id = "sres15"
         self._description = "Which alerts self-resolve within 15 minutes?"
 
     def _query(self):
         # pylint: disable=singleton-comparison
         return (
-            self._db_session.query(Alert)
-            .filter(Alert.created_at.between(self._since, self._until))
+            super()
+            ._query()
             .filter(~Alert.incident.has(Incident.resolved_at == None))
             .filter(
                 Alert.incident.has(
@@ -236,16 +244,16 @@ class QSREResolvedImmediately(Question):
     Which alerts are resolved by SRE within 15 minutes of firing?
     """
 
-    def __init__(self, db_session, since, until):
-        super().__init__(db_session, since, until)
+    def __init__(self, db_session, since, until, region):
+        super().__init__(db_session, since, until, region)
         self._id = "eres15"
         self._description = "Which alerts are resolved within 15 minutes by SRE?"
 
     def _query(self):
         # pylint: disable=singleton-comparison
         return (
-            self._db_session.query(Alert)
-            .filter(Alert.created_at.between(self._since, self._until))
+            super()
+            ._query()
             .filter(~Alert.incident.has(Incident.resolved_at == None))
             .filter(
                 ~Alert.incident.has(
@@ -266,8 +274,8 @@ class QFlappingShift(Question):
     Which alerts fire more than once per on-call shift (in the same cluster)?
     """
 
-    def __init__(self, db_session, since, until):
-        super().__init__(db_session, since, until)
+    def __init__(self, db_session, since, until, region):
+        super().__init__(db_session, since, until, region)
         self._id = "sflap"
         self._description = (
             "Which alerts fire more than once per on-call shift (in the same cluster)?"

--- a/webui.py
+++ b/webui.py
@@ -74,4 +74,6 @@ class WebUISession:
         self.question_instances = []
         for question_class_name in QUESTION_CLASSES:
             question = getattr(questions, question_class_name)
-            self.question_instances.append(question(self.db_session, since, until))
+            self.question_instances.append(
+                question(self.db_session, since, until, region.value)
+            )

--- a/webui.py
+++ b/webui.py
@@ -32,10 +32,13 @@ class StandardDataTable(DataTable):
         """
         Simplified, opinionated constructor for DataTable
         """
+        # Sort by the last column in descending order
+        sorted_col = list(cd["id"] for cd in columns)[-1]
         super().__init__(
             row_selectable="single",
             filter_action="native",
             sort_action="native",
+            sort_by=[{"column_id": sorted_col, "direction": "desc"}],
             sort_mode="multi",
             page_action="native",
             page_current=0,

--- a/webui.py
+++ b/webui.py
@@ -12,7 +12,12 @@ from models import Base
 
 
 class Region(Enum):
-    GLOBAL = "*"
+    """
+    Enumerated type for on-call regions. Should roughly match regions defined in DB's
+    shift column
+    """
+
+    GLOBAL = "Global"
     APAC = "APAC"
     EMEA = "EMEA"
     NASA = "NASA"

--- a/webui.py
+++ b/webui.py
@@ -1,6 +1,7 @@
 """
 Classes for displaying PagerDuty analysis results
 """
+from enum import Enum
 from dash.dash_table import DataTable
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -8,6 +9,13 @@ from sqlalchemy.orm import sessionmaker
 import questions
 from config import QUESTION_CLASSES, RO_DB_STRING
 from models import Base
+
+
+class Region(Enum):
+    GLOBAL = "*"
+    APAC = "APAC"
+    EMEA = "EMEA"
+    NASA = "NASA"
 
 
 class StandardDataTable(DataTable):
@@ -38,7 +46,7 @@ class WebUISession:
     Singleton connection holder
     """
 
-    def __init__(self, since, until) -> None:
+    def __init__(self, since, until, region) -> None:
         """
         Constructor for WebUISession. Manages database connection and instantiates
         Question objects
@@ -47,10 +55,12 @@ class WebUISession:
             which queries will be evaluated
         :param until: a datetime.datetime containing the end of the time window over
             which queries will be evaluated
+        :param region: a Region enum representing the region of interest
         """
         # pylint: disable=invalid-name
         self._since = since
         self._until = until
+        self._region = region
         self._engine = create_engine(RO_DB_STRING, future=True)
         Session = sessionmaker(bind=self._engine)
         self.db_session = Session()

--- a/wsgi.py
+++ b/wsgi.py
@@ -86,7 +86,7 @@ def display_page(pathname):
     """
     Generates page content on URL change (i.e., page load)
     """
-    max_date = datetime.now(timezone.utc) - timedelta(days=1)
+    max_date = datetime.now(timezone.utc)
     try:
         clean_params_list = re.sub(r"[^\d\w/-]+", "", pathname.strip("/")).rsplit(
             "/", 3
@@ -95,7 +95,7 @@ def display_page(pathname):
         until = datetime.fromisoformat(clean_params_list[1])
         region = Region(clean_params_list[2])
     except (ValueError, IndexError):
-        since = max_date - timedelta(days=30)
+        since = max_date - timedelta(days=7)
         until = max_date
         region = Region.GLOBAL
 


### PR DESCRIPTION
This PR adds a region menu to the navigation bar, allowing the user to filter their query by the region that was on-call at the time of Alert's firing. On the backend, this filter has been implemented similarly to the `since` and `until` date range query filters (i.e., as a parameter to the construction of `Question`). Evaluation of these 3 "core" filters has been moved into the `Question._query()` base-class method, allowing child classes to simply call `super()._query()` instead of needing to repeat the 3 filters.

This PR also improves the default settings for the webUI: Answer tables are now sorted by their last columns by default, and the default search window is now 7 days instead of 30.

This addresses [OSD-11385](https://issues.redhat.com/browse/OSD-11385), where team leads requested this feature in order to make OAA more useful for regional ops reviews. 