### PR TITLE
Set web page title

### DIFF
--- a/wsgi.py
+++ b/wsgi.py
@@ -13,6 +13,7 @@ from webui import StandardDataTable, WebUISession, Region
 
 app = Dash(__name__, external_stylesheets=[dbc.themes.BOOTSTRAP])
 application = app.server
+app.title = "OSD Alert Analysis"
 
 
 def get_navbar(since, until, max_date, region):


### PR DESCRIPTION
This purely-cosmetic one-line PR simply sets the title of the webUI page to "OSD Alert Analysis," instead of the default "Dash."