### PR TITLE
Increase gunicorn timeout to deal with long DB waits

### DIFF
--- a/devops/DeployTemplate.yaml
+++ b/devops/DeployTemplate.yaml
@@ -52,6 +52,9 @@ objects:
                     name: alert-analysis-database-ro
                 - secretRef:
                     name: alert-analysis-pagerduty-token
+              env:
+              - name: APP_CONFIG
+                value: "/opt/app-root/src/gunicorn.conf.py"
               ports:
                 - containerPort: ${{appport}}
               readinessProbe:

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,0 +1,2 @@
+# Temporary fix to very-long database queries (see OSD-14138)
+timeout = 60


### PR DESCRIPTION
This small PR increases the gunicorn worker timeout to 60 seconds from 30. This should provide a temporary fix for [OSD-14339](https://issues.redhat.com/browse/OSD-14339), where very long waits for replies from the SQL database are causing gunicorn workers to timeout (preventing the web page from loading). 