### PR TITLE
Add archival notice to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+# WARNING: This project has been archived and is no longer actively maintained.
+_If you wish to continue to use or develop this code yourself, we recommend you fork this repository._
+
+![status: inactive](https://img.shields.io/badge/status-inactive-red.svg)
+
 # OSD Alert Analysis
 
 Web application and supporting CLI tools for analyzing OpenShift Dedicated PagerDuty


### PR DESCRIPTION
OAA has been decommissioned. Per [OSD-18430](https://issues.redhat.com/browse/OSD-18430), this PR adds an archival notice to the README.